### PR TITLE
Fix time problem (Shuttle)

### DIFF
--- a/src/screens/Shuttle.tsx
+++ b/src/screens/Shuttle.tsx
@@ -160,8 +160,9 @@ function checkOperating(shuttle: ShuttleType): {
   isOperating: boolean;
   operating: ShuttleType['operatings'][number] | null;
 } {
+  const now = getNow();
   const {operatings} = shuttle;
-  const day = getDay(getNow);
+  const day = getDay(now);
 
   if (!shuttle.name.includes('심야') && (day === 0 || day === 6)) {
     return {isOperating: false, operating: null};
@@ -175,11 +176,11 @@ function checkOperating(shuttle: ShuttleType): {
     const startAt = parseTime(
       startAtString === '24:00' ? '23:59' : startAtString,
       'HH:mm',
-      getNow,
+      now,
     );
-    const endedAt = parseTime(endedAtString, 'HH:mm', getNow);
+    const endedAt = parseTime(endedAtString, 'HH:mm', now);
 
-    if (compareAsc(startAt, getNow) < 0 && compareAsc(getNow, endedAt) < 0) {
+    if (compareAsc(startAt, now) < 0 && compareAsc(now, endedAt) < 0) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
### 변경 내용

- 셔틀 페이지에서 운영 중임에도 미운영중으로 뜨는 문제를 해결했습니다.
- 원인은 셔틀 페이지에서만 ```checkOperating``` 함수에서 ``` getDay(getNow) ``` 처럼 쓰고 있었습니다.
- 다른 페이지들 처럼 ```const now = getNow()``` 로 함수 처음에 지정해주고 모든 ```getNow``` 를 ```now``` 로 바꿔줬습니다.

### 궁금한 점

- ```checkOperating``` 함수를 보면 일부 페이지는 ```const now = getNow()``` 가 함수 밖에 있고 일부는 함수 안에 있는데,
- 둘이 차이가 존재하는지? 존재한다면 어떤게 더 현재 시간을 잘 반영할 수 있을지?