### PR TITLE
식단 표기 개선

### DIFF
--- a/src/InitializeData/RefineMenuText.ts
+++ b/src/InitializeData/RefineMenuText.ts
@@ -31,6 +31,7 @@ const RefineFetchedMenuOf: {
   default: function (text: string) {
     return text
       .replace(/.파업/, '※')
+      .replaceAll(' (', '(')
       .split('00원')
       .map((item: string) => {
         return item

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -256,7 +256,7 @@ const List = <T extends AvailableItem>(props: Props<T>) => {
       {sortedItems ? (
         <Box>
           <ScrollView bgColor={colors.white}>
-            <VStack width="85%" marginLeft="7.5%">
+            <VStack width="85%" marginLeft="7.5%" paddingBottom="15px">
               {chain(sortedItems)
                 .map(item => {
                   return <ItemButton key={item.name} item={item} />;

--- a/src/components/MoreModal.tsx
+++ b/src/components/MoreModal.tsx
@@ -9,6 +9,8 @@ import KebabIcon from '../icons/kebab.svg';
 import PressedKebabIcon from '../icons/kebab-pressed.svg';
 import OutlinkIcon from '../icons/outlink.svg';
 import PressedOutlinkIcon from '../icons/outlink-pressed.svg';
+import ExternalIcon from '../icons/external.svg';
+import PressedExternalIcon from '../icons/external-pressed.svg';
 import BackIcon from '../icons/back.svg';
 import PressedBackIcon from '../icons/back-pressed.svg';
 import {theme} from '../ui/theme';
@@ -236,7 +238,7 @@ export default function MoreModal() {
                           }>
                           개발자들 보러 가기
                         </Text>
-                        {isPressed ? <PressedOutlinkIcon /> : <OutlinkIcon />}
+                        {isPressed ? <PressedExternalIcon /> : <ExternalIcon />}
                       </Center>
                     );
                   }}

--- a/src/helpers/convertToKoreanDay.ts
+++ b/src/helpers/convertToKoreanDay.ts
@@ -20,5 +20,4 @@ export const convertToKoreanDay = (day: 0 | 1 | 2 | 3 | 4 | 5 | 6) => {
   if (day === 6) {
     return '토';
   }
-  throw Error('이럴리없다.');
 };

--- a/src/icons/external-gray.svg
+++ b/src/icons/external-gray.svg
@@ -1,0 +1,5 @@
+
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 2H3C2.44771 2 2 2.44772 2 3V17C2 17.5523 2.44772 18 3 18H17C17.5523 18 18 17.5523 18 17V12H20V17C20 18.6569 18.6569 20 17 20H3C1.34315 20 0 18.6569 0 17V3C0 1.34315 1.34315 0 3 0H8V2Z" fill="#636363"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 0H18H20V2V8H18V3.42843L8.41421 13.0142L7 11.6L16.6 2H12V0Z" fill="#636363"/>
+</svg>

--- a/src/icons/external-pressed.svg
+++ b/src/icons/external-pressed.svg
@@ -1,0 +1,5 @@
+
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 2H3C2.44771 2 2 2.44772 2 3V17C2 17.5523 2.44772 18 3 18H17C17.5523 18 18 17.5523 18 17V12H20V17C20 18.6569 18.6569 20 17 20H3C1.34315 20 0 18.6569 0 17V3C0 1.34315 1.34315 0 3 0H8V2Z" fill="#4451DE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 0H18H20V2V8H18V3.42843L8.41421 13.0142L7 11.6L16.6 2H12V0Z" fill="#4451DE"/>
+</svg>

--- a/src/icons/external.svg
+++ b/src/icons/external.svg
@@ -1,4 +1,4 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M8 2H3C2.44771 2 2 2.44772 2 3V17C2 17.5523 2.44772 18 3 18H17C17.5523 18 18 17.5523 18 17V12H20V17C20 18.6569 18.6569 20 17 20H3C1.34315 20 0 18.6569 0 17V3C0 1.34315 1.34315 0 3 0H8V2Z" fill="#636363"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M12 0H18H20V2V8H18V3.42843L8.41421 13.0142L7 11.6L16.6 2H12V0Z" fill="#636363"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 2H3C2.44771 2 2 2.44772 2 3V17C2 17.5523 2.44772 18 3 18H17C17.5523 18 18 17.5523 18 17V12H20V17C20 18.6569 18.6569 20 17 20H3C1.34315 20 0 18.6569 0 17V3C0 1.34315 1.34315 0 3 0H8V2Z" fill="#0C146B"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 0H18H20V2V8H18V3.42843L8.41421 13.0142L7 11.6L16.6 2H12V0Z" fill="#0C146B"/>
 </svg>

--- a/src/icons/outlink-gray.svg
+++ b/src/icons/outlink-gray.svg
@@ -1,10 +1,3 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M20.2132 12.6066L9.6066 2L7.48528 4.12132L15.9706 12.6066L7.48527 21.0919L9.6066 23.2132L20.2132 12.6066Z" fill="#636363"/>
-</g>
-<defs>
-<clipPath id="clip0">
-<rect width="25" height="25" fill="white"/>
-</clipPath>
-</defs>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.0919 9.98528L9.6066 1.5L7.90955 3.19705L14.6978 9.98528L7.90955 16.7735L1.12132 9.98528L9.6066 18.4706L18.0919 9.98528Z" fill="#636363"/>
 </svg>

--- a/src/icons/outlink-pressed.svg
+++ b/src/icons/outlink-pressed.svg
@@ -1,10 +1,3 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M20.2132 12.6066L9.6066 2L7.48528 4.12132L15.9706 12.6066L7.48527 21.0919L9.6066 23.2132L20.2132 12.6066Z" fill="#4451DE"/>
-</g>
-<defs>
-<clipPath id="clip0">
-<rect width="25" height="25" fill="white"/>
-</clipPath>
-</defs>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.0919 9.98528L9.6066 1.5L7.90955 3.19705L14.6978 9.98528L7.90955 16.7735L1.12132 9.98528L9.6066 18.4706L18.0919 9.98528Z" fill="#4451DE"/>
 </svg>

--- a/src/icons/outlink.svg
+++ b/src/icons/outlink.svg
@@ -1,10 +1,3 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M20.2132 12.6066L9.6066 2L7.48528 4.12132L15.9706 12.6066L7.48527 21.0919L9.6066 23.2132L20.2132 12.6066Z" fill="#0C146B"/>
-</g>
-<defs>
-<clipPath id="clip0">
-<rect width="25" height="25" fill="white"/>
-</clipPath>
-</defs>
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.0919 9.98528L9.6066 1.5L7.90955 3.19705L14.6978 9.98528L7.90955 16.7735L1.12132 9.98528L9.6066 18.4706L18.0919 9.98528Z" fill="#0C146B"/>
 </svg>

--- a/src/screens/Etcs.tsx
+++ b/src/screens/Etcs.tsx
@@ -14,7 +14,7 @@ import React, {useCallback, useState} from 'react';
 import {Linking} from 'react-native';
 import {colors} from '../ui/colors';
 import OutlinkIcon from '../icons/outlink-gray.svg';
-import ExternalIcon from '../icons/external.svg';
+import ExternalIcon from '../icons/external-gray.svg';
 
 export default function Etcs() {
   const [focusedEtc, setFocusedEtc] = useState<'Post' | 'Book' | 'Bank' | null>(


### PR DESCRIPTION
### 변경 내용
- 앞의 두 커밋은 #62 와 겹칩니다
- RefineMenuText: 메뉴 이름과 괄호 사이에 공백이 있을 때 표기에 문제가 발생해서 고쳤습니다
- convertToKoreanDay : 이제 필요 없어진 throw 이럴리없다를 삭제했습니다