### PR TITLE
fix android error (remove string.replaceAll)

### DIFF
--- a/src/InitializeData/RefineMenuText.ts
+++ b/src/InitializeData/RefineMenuText.ts
@@ -31,7 +31,8 @@ const RefineFetchedMenuOf: {
   default: function (text: string) {
     return text
       .replace(/.파업/, '※')
-      .replaceAll(' (', '(')
+      .split(' (')
+      .join('(')
       .split('00원')
       .map((item: string) => {
         return item
@@ -191,7 +192,8 @@ const RefineFetchedMenuOf: {
     return text
       .trim()
       .split('※')[0]
-      .replaceAll('&amp;', '&')
+      .split('&amp;')
+      .join('&')
       .replace('&lt;', '<')
       .replace('&gt;', '>')
       .split('00원')


### PR DESCRIPTION
### 변경 내용
- javascript의 최신 함수인 replaceAll 함수를 사용할 경우 android에서 문제가 발생하는데, 그 문제를 고쳤습니다. (replaceAll 대신 split(), join() 사용하여 같은 기능 구현)