### PR TITLE
자하연 식당 교직원 메뉴 표기되는 현상 수정

### DIFF
--- a/src/InitializeData/RefineMenuText.ts
+++ b/src/InitializeData/RefineMenuText.ts
@@ -57,6 +57,7 @@ const RefineFetchedMenuOf: {
   자하연: function (text: string) {
     return text
       .replace(/.파업/, '※')
+      .replace(/\( ?3층/, '※')
       .split('※')[0]
       .split('00원')
       .map((item: string) => {


### PR DESCRIPTION
### 변경 내용
- snuco의 자하연 식당 text의 변칙으로 교직원식당 메뉴가 함께 표기되는 상황을 막았습니다