### PR TITLE
셔틀 운영 종료 시간 및 운영 예정 시간 표기 추가

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
   Divider,
   Row,
+  Column,
 } from 'native-base';
 import React, {useCallback, useMemo, useState} from 'react';
 import FilledStarIcon from '../icons/filled-star.svg';
@@ -36,6 +37,7 @@ type ItemWithFlag<T> = T & {
   isOperating: boolean;
   interval: string | null;
   favoriteRate: number;
+  partition: string | null;
 };
 
 const FocusedModal = <T extends AvailableItem>({
@@ -104,22 +106,33 @@ const FocusedModal = <T extends AvailableItem>({
               대수
             </Text>
           </HStack>
-          {item.operatings.map(operating => (
-            <Box key={operating.time}>
-              <Divider my={3} bg="black" width="100%" marginY="14px" />
-              <HStack key={operating.time} width="100%" alignItems="center">
-                <Text width="30%" variant="modalSubContent" textAlign="center">
-                  {operating.time}
-                </Text>
-                <Text width="50%" variant="modalSubContent" textAlign="center">
-                  {operating.interval}
-                </Text>
-                <Text width="20%" variant="modalSubContent" textAlign="center">
-                  {operating.numbers}
-                </Text>
-              </HStack>
-            </Box>
-          ))}
+          {item.operatings.map(operating =>
+            operating.interval ? (
+              <Box key={operating.time}>
+                <Divider my={3} bg="black" width="100%" marginY="14px" />
+                <HStack key={operating.time} width="100%" alignItems="center">
+                  <Text
+                    width="30%"
+                    variant="modalSubContent"
+                    textAlign="center">
+                    {operating.time}
+                  </Text>
+                  <Text
+                    width="50%"
+                    variant="modalSubContent"
+                    textAlign="center">
+                    {operating.interval}
+                  </Text>
+                  <Text
+                    width="20%"
+                    variant="modalSubContent"
+                    textAlign="center">
+                    {operating.numbers}
+                  </Text>
+                </HStack>
+              </Box>
+            ) : null,
+          )}
         </VStack>
         <Text marginBottom="2px" />
       </Modal.Content>
@@ -151,6 +164,7 @@ const List = <T extends AvailableItem>(props: Props<T>) => {
             isOperating,
             favoriteRate,
             interval: operating?.interval ?? null,
+            partition: operating?.partition ?? null,
           };
         })
         .sortBy(({isOperating, favoriteRate}) => {
@@ -200,7 +214,7 @@ const List = <T extends AvailableItem>(props: Props<T>) => {
   const handleCloseFocusedModal = useCallback(() => setFocusedItem(null), []);
 
   const ItemButton = ({item}: {item: ItemWithFlag<T>}) => {
-    const {name, isOperating, favoriteRate, interval} = item;
+    const {name, isOperating, favoriteRate, interval, partition} = item;
     const tags = useMemo(
       () => ({
         itemType,
@@ -219,30 +233,37 @@ const List = <T extends AvailableItem>(props: Props<T>) => {
           label={`${itemType}-click-button`}
           tags={tags}
           width="100%"
-          height="72px"
-          paddingLeft="15px"
+          height={isOperating ? '80px' : '72px'}
+          paddingLeft="20px"
           variant={favoriteRate ? 'favoritePlace' : 'normalPlace'}
           onPress={onPress}>
           <Center flexDirection="row">
             <Row height="100%" width="100%" alignItems="center">
-              <Text
-                width="64%"
-                variant={
-                  favoriteRate > 0
-                    ? isOperating
-                      ? 'favoriteOpenPlaceNameBig'
-                      : 'favoriteClosedPlaceNameBig'
-                    : isOperating
-                    ? 'normalOpenPlaceBig'
-                    : 'normalClosedPlaceBig'
-                }>
-                {name}
-              </Text>
+              <Column width="64%" alignItems="flex-start">
+                <Text
+                  width="100%"
+                  variant={
+                    favoriteRate > 0
+                      ? isOperating
+                        ? 'favoriteOpenPlaceNameBig'
+                        : 'favoriteClosedPlaceNameBig'
+                      : isOperating
+                      ? 'normalOpenPlaceBig'
+                      : 'normalClosedPlaceBig'
+                  }>
+                  {name}
+                </Text>
+                {isOperating ? (
+                  <Text variant="favoritePlaceTime" marginTop="4px">
+                    {partition}
+                  </Text>
+                ) : null}
+              </Column>
               <Text
                 textAlign="center"
                 width="36%"
                 variant={interval ? 'favoriteMenuName' : 'favoriteClosedInfo'}>
-                {interval ? `배차간격: ${interval}` : '미운행중'}
+                {interval ? `배차간격: ${interval}` : partition ?? '운행 종료'}
               </Text>
             </Row>
           </Center>

--- a/src/screens/Shuttle.tsx
+++ b/src/screens/Shuttle.tsx
@@ -286,10 +286,16 @@ const SHUTTLES: ShuttleType[] = [
         partition: '02:00까지 운행',
       },
       {
-        time: '02:00~23:59',
+        time: '02:00~18:00',
         interval: null,
         numbers: null,
-        partition: '자정부터 운행',
+        partition: '운행 종료',
+      },
+      {
+        time: '18:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '자정부터 운행 예정',
       },
     ],
   },

--- a/src/screens/Shuttle.tsx
+++ b/src/screens/Shuttle.tsx
@@ -10,7 +10,12 @@ type Props = {
 
 export type ShuttleType = {
   name: string;
-  operatings: {time: string; interval: string; numbers: string}[];
+  operatings: {
+    time: string;
+    interval: string | null;
+    numbers: string | null;
+    partition: string;
+  }[];
 };
 
 const SHUTTLES: ShuttleType[] = [
@@ -18,34 +23,58 @@ const SHUTTLES: ShuttleType[] = [
     name: '설입 ↔ 행정관',
     operatings: [
       {
+        time: '00:00~07:00',
+        interval: null,
+        numbers: null,
+        partition: '07:00 운행 예정',
+      },
+      {
         time: '07:00~08:00',
         interval: '15분',
         numbers: '2대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '08:00~11:00',
         interval: '3~4분',
         numbers: '9대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '11:00~15:00',
         interval: '10분',
         numbers: '3대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '15:00~18:00',
         interval: '3~4분',
         numbers: '9대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '18:00~19:00',
         interval: '3~4분\n(하교셔틀만 운영)',
         numbers: '9대',
+        partition: '하교 ~19:00',
+      },
+      {
+        time: '19:00~21:10',
+        interval: null,
+        numbers: null,
+        partition: '21:10 운행 예정',
       },
       {
         time: '21:10~23:10',
         interval: '30분',
         numbers: '2대',
+        partition: '23:10까지 운행',
+      },
+      {
+        time: '23:10~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -53,29 +82,52 @@ const SHUTTLES: ShuttleType[] = [
     name: '녹두 ↔ 행정관',
     operatings: [
       {
+        time: '00:00~07:00',
+        interval: null,
+        numbers: null,
+        partition: '07:00 운행 예정',
+      },
+      {
         time: '07:00~08:00',
         interval: '15분',
         numbers: '1대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '08:00~11:00',
         interval: '6분',
         numbers: '3대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '11:00~18:00',
         interval: '10분',
         numbers: '2대',
+        partition: '등교 ~18:00, 하교 ~19:00',
       },
       {
         time: '18:00~19:00',
         interval: '10분\n(하교셔틀만 운영)',
         numbers: '2대',
+        partition: '하교 ~19:00',
+      },
+      {
+        time: '19:00~21:10',
+        interval: null,
+        numbers: null,
+        partition: '21:10 운행 예정',
       },
       {
         time: '21:10~23:10',
         interval: '30분',
         numbers: '2대',
+        partition: '23:10까지 운행',
+      },
+      {
+        time: '23:10~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -83,9 +135,22 @@ const SHUTTLES: ShuttleType[] = [
     name: '사당 ↔ 행정관',
     operatings: [
       {
+        time: '00:00~08:00',
+        interval: null,
+        numbers: null,
+        partition: '08:00 운행 예정',
+      },
+      {
         time: '08:00~11:00',
         interval: '10분',
         numbers: '4대',
+        partition: '11:00까지 운행',
+      },
+      {
+        time: '11:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -93,9 +158,22 @@ const SHUTTLES: ShuttleType[] = [
     name: '설입 → 윗공대',
     operatings: [
       {
+        time: '00:00~08:00',
+        interval: null,
+        numbers: null,
+        partition: '08:00 운행 예정',
+      },
+      {
         time: '08:00~11:00',
         interval: '6~8분',
         numbers: '5대',
+        partition: '11:00까지 운행',
+      },
+      {
+        time: '11:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -103,9 +181,22 @@ const SHUTTLES: ShuttleType[] = [
     name: '낙성대 → 윗공대',
     operatings: [
       {
+        time: '00:00~08:30',
+        interval: null,
+        numbers: null,
+        partition: '08:30 운행 예정',
+      },
+      {
         time: '08:30~11:00',
         interval: '5분',
         numbers: '7대',
+        partition: '11:00까지 운행',
+      },
+      {
+        time: '11:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -113,14 +204,28 @@ const SHUTTLES: ShuttleType[] = [
     name: '교내 순환',
     operatings: [
       {
+        time: '00:00~08:00',
+        interval: null,
+        numbers: null,
+        partition: '08:00 운행 예정',
+      },
+      {
         time: '08:00~19:00',
         interval: '5~6분',
         numbers: '3~4대',
+        partition: '21:00까지 운행',
       },
       {
         time: '19:00~21:00',
         interval: '20분',
         numbers: '1대',
+        partition: '21:00까지 운행',
+      },
+      {
+        time: '21:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -128,19 +233,46 @@ const SHUTTLES: ShuttleType[] = [
     name: '교내 역순환',
     operatings: [
       {
+        time: '00:00~09:50',
+        interval: null,
+        numbers: null,
+        partition: '09:50 운행 예정',
+      },
+      {
         time: '09:50~12:50',
         interval: '20분',
         numbers: '2대',
+        partition: '17:10까지 운행',
+      },
+      {
+        time: '12:50~13:30',
+        interval: null,
+        numbers: null,
+        partition: '13:30 운행 예정',
       },
       {
         time: '13:30~15:10',
         interval: '40~60분',
         numbers: '2대',
+        partition: '17:10까지 운행',
+      },
+      {
+        time: '15:10~15:30',
+        interval: null,
+        numbers: null,
+        partition: '15:30부터 ',
       },
       {
         time: '15:30~17:10',
         interval: '20분',
         numbers: '2대',
+        partition: '17:10까지 운행',
+      },
+      {
+        time: '17:10~23:59',
+        interval: null,
+        numbers: null,
+        partition: '운행 종료',
       },
     ],
   },
@@ -151,15 +283,24 @@ const SHUTTLES: ShuttleType[] = [
         time: '00:00~02:00',
         interval: '30분',
         numbers: '1대',
+        partition: '02:00까지 운행',
+      },
+      {
+        time: '02:00~23:59',
+        interval: null,
+        numbers: null,
+        partition: '자정부터 운행',
       },
     ],
   },
 ];
 
-function checkOperating(shuttle: ShuttleType): {
-  isOperating: boolean;
-  operating: ShuttleType['operatings'][number] | null;
-} {
+function checkOperating(shuttle: ShuttleType):
+  | {
+      isOperating: true;
+      operating: ShuttleType['operatings'][number];
+    }
+  | {isOperating: false; operating: ShuttleType['operatings'][number] | null} {
   const now = getNow();
   const {operatings} = shuttle;
   const day = getDay(now);
@@ -167,8 +308,17 @@ function checkOperating(shuttle: ShuttleType): {
   if (!shuttle.name.includes('심야') && (day === 0 || day === 6)) {
     return {isOperating: false, operating: null};
   }
-  if (shuttle.name.includes('심야') && (day === 0 || day === 1)) {
-    return {isOperating: false, operating: null};
+  if (shuttle.name.includes('심야')) {
+    // 00:00 ~ 02:00 심야셔틀이 운행 안하는 요일은 일요일, 월요일 새벽
+    // 다음날 심야셔틀이 운행 안하는 요일은 토요일, 일요일
+    if (
+      compareAsc(now, parseTime('02:00', 'HH:mm', now)) < 0 &&
+      (day === 0 || day === 1)
+    ) {
+      return {isOperating: false, operating: null};
+    } else if (day === 0 || day === 6) {
+      return {isOperating: false, operating: null};
+    }
   }
 
   const operating = find(operatings, o => {
@@ -187,10 +337,10 @@ function checkOperating(shuttle: ShuttleType): {
     }
   });
 
-  if (operating) {
+  if (operating && operating.interval != null) {
     return {isOperating: true, operating};
   } else {
-    return {isOperating: false, operating: null};
+    return {isOperating: false, operating: operating ?? null};
   }
 }
 


### PR DESCRIPTION
### 변경 내용

- 메인 화면에서 운영 중인 셔틀은 운영 종료 시간을, 운영 중이지 않은 셔틀은 운영 예정 시간 표기를 추가했습니다.
- 주말처럼 아예 셔틀이 운행중이지 않을 때는 __운행 종료__ 로, 셔틀 운행 전인 아침이나 운행 시간 사이에는 운행 예정 시간을 적어줬습니다.
- 심야 셔틀의 경우 토요일 새벽 운행이 끝난 후부터 월요일 새벽까지는 __운행 종료__ 로, 평일 저녁~자정 까지는 운행 예정 시간을 적어줬습니다.